### PR TITLE
Update NirvanaBrewing.java

### DIFF
--- a/common/src/main/java/galena/nirvana/index/NirvanaBrewing.java
+++ b/common/src/main/java/galena/nirvana/index/NirvanaBrewing.java
@@ -47,15 +47,25 @@ public class NirvanaBrewing {
 
         var catalysts = BuiltInRegistries.ITEM.stream()
                 .map(ItemStack::new)
-                .filter(vanilla::isIngredient)
-                .toList();
+                .filter(stack -> {
+                    try {
+                        return vanilla.isIngredient(stack);
+                    } catch (IllegalStateException e) {
+                        return false;
+                    }
+                }).toList();
 
         BuiltInRegistries.POTION.holders().forEach(potion -> {
             var from = withPotion(NirvanaItems.POTION_BONG, potion);
             var potionStack = withPotion(Items.POTION, potion);
             catalysts.stream()
-                    .filter(it -> vanilla.hasMix(potionStack, it))
-                    .forEach(catalyst -> registerMix(builder, catalyst, from));
+                    .filter(it -> {
+                        try {
+                            return vanilla.hasMix(potionStack, it);
+                        } catch (IllegalStateException e) {
+                            return false;
+                        }
+                    }).forEach(catalyst -> registerMix(builder, catalyst, from));
         });
     }
 


### PR DESCRIPTION
This Closes issue #88 

Fixes a crash that happens when loading a world with mods that haven't loaded their config at bootstrap, (in my case with Corail Tombstone)

Specifically this fix wraps both isIngredient and hasMix with a try catch so when "IllegalStateException: Cannot get config value before config is loaded" is thrown it skips that config value, this happens because those server config aren't loaded during the PotionBrewing.bootstrap. From what I've seen this doesn't effect the logic at all, which is to be expected and bong recipes are still being generated correctly (like the brain damage bong). 

those items that throw the error simply won't get bong recipes generated for them, which is the same outcome as if the other mod wasn't installed, I would make a issue report for corail tombstones but as said in issue 88, their issues are closed at the moment. 